### PR TITLE
Force create logging

### DIFF
--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -3,7 +3,7 @@
 import sys
 import os
 import yaml
-import click
+import logging
 from src.validation.validate import DataValidator
 
 def load_config(config_path: str) -> dict:
@@ -21,12 +21,28 @@ def load_config(config_path: str) -> dict:
         print(f"Error loading config file: {e}")
         sys.exit(1)
 
-@click.command()
 def main():
     # Add the project root to sys.path
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     if project_root not in sys.path:
         sys.path.insert(0, project_root)
+
+    # Create logs directory if it doesn't exist
+    logs_dir = os.path.join(project_root, "logs")
+    os.makedirs(logs_dir, exist_ok=True)
+    
+    # Create .gitkeep file in logs directory
+    gitkeep_path = os.path.join(logs_dir, ".gitkeep")
+    if not os.path.exists(gitkeep_path):
+        with open(gitkeep_path, 'w') as f:
+            pass  # Create empty file
+
+    # Configure logging
+    logging.basicConfig(
+        filename=os.path.join(logs_dir, "correlation_errors.log"),
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
 
     # Load configuration
     config_path = os.path.join(project_root, "config", "validation_config.yaml")

--- a/src/validation/correlation_validator.py
+++ b/src/validation/correlation_validator.py
@@ -2,12 +2,6 @@ import logging
 import pandas as pd
 from deepchecks.tabular import Dataset
 from deepchecks.tabular.checks import FeatureLabelCorrelation, FeatureFeatureCorrelation
-logging.basicConfig(
-        filename="logs/correlation_errors.log",
-        filemode="a",
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        level=logging.INFO,
-    )
 
 class CorrelationValidator:
     def __init__(self, target: str, feature_threshold: float = 0.9, feature_feature_threshold: float = 0.8,


### PR DESCRIPTION
Fix for #61 

This pull request includes changes to the logging configuration and the removal of a dependency in the `scripts/run_validation.py` file. The most important changes include setting up a logging configuration in the main script and removing the `click` dependency.

Logging configuration:

* [`scripts/run_validation.py`](diffhunk://#diff-4a7a926a43d976bc2fc0cfb78839df350e02f9e6191061859727d48c01101f66L24-R46): Added logging configuration to log correlation errors and created a `logs` directory with a `.gitkeep` file if it does not exist.

Dependency removal:

* [`scripts/run_validation.py`](diffhunk://#diff-4a7a926a43d976bc2fc0cfb78839df350e02f9e6191061859727d48c01101f66L6-R6): Removed the import of `click` and the `@click.command()` decorator. [[1]](diffhunk://#diff-4a7a926a43d976bc2fc0cfb78839df350e02f9e6191061859727d48c01101f66L6-R6) [[2]](diffhunk://#diff-4a7a926a43d976bc2fc0cfb78839df350e02f9e6191061859727d48c01101f66L24-R46)

Codebase simplification:

* [`src/validation/correlation_validator.py`](diffhunk://#diff-7dd4331a43215edb9c3e8d0aab30fe13a2fc8c9e355cba3da4508bb3bb1b6404L5-L10): Removed redundant logging configuration since logging is now handled in the main script.…th .gitkeep. Remove click command because in the Makefile and Readme doesn't specify click.