### PR TITLE
Add 'make' to Dockerfile dependencies and format installation commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,17 @@ RUN conda init bash && \
 USER root
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends lmodern librsvg2-bin && \
+    apt-get install -y --no-install-recommends \
+    lmodern \
+    librsvg2-bin \
+    make && \ 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /home/jovyan/.cache/conda && \
     chown -R $NB_UID:$NB_GID /home/jovyan/.cache && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
+
 
 RUN pip install \
 pandera==0.21.0 \


### PR DESCRIPTION
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L16-R27): Added the `make` package to the list of installed packages and reformatted the `apt-get install` command to list each package on a new line for better readability.