### PR TITLE
modify Docker image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,3 +43,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update docker-compose.yml with new image tag
+        if: success()
+        run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   taxi_fare_predictor:
     build: .
     platform: linux/amd64
-    image: lixuanlin/taxi-fare-predictor:latest
+    image: lixuanlin/taxi-fare-predictor:95968c8
     #image: local-taxi-predictor
     ports:
       - "8888:8888"


### PR DESCRIPTION
- pin the image version in docker-publish.yml
- add a step to your docker-publish.yml workflow so that it automatically updates the docker-compose.yml file with the tag of the new image that is built and published
- tested okay